### PR TITLE
Add containing predicate

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -39,7 +39,6 @@ type StringOperators = {
   startsWith?: string;
   endsWith?: string;
   contains?: string;
-  containing?: string;
 };
 
 type WhereConditions = NumberOperators | DateOperators | StringOperators;
@@ -160,10 +159,7 @@ const handleObjectCondition = (
         condition = `${prefix}${key} LIKE ${escape("%", value)}`;
         break;
       case "contains":
-        condition = `${prefix}${key} LIKE ${escape("%", value, "%")}`;
-        break;
-      case "containing":
-        condition = `${prefix}${key} CONTAINING ${escape( value )}`;
+        condition = `${prefix}${key} CONTAINING ${escape(value)}`;
         break;
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,7 @@ type StringOperators = {
   startsWith?: string;
   endsWith?: string;
   contains?: string;
+  containing?: string;
 };
 
 type WhereConditions = NumberOperators | DateOperators | StringOperators;
@@ -160,6 +161,9 @@ const handleObjectCondition = (
         break;
       case "contains":
         condition = `${prefix}${key} LIKE ${escape("%", value, "%")}`;
+        break;
+      case "containing":
+        condition = `${prefix}${key} CONTAINING ${escape( value )}`;
         break;
     }
 


### PR DESCRIPTION
I added containing predicate to list of string operators to make it work with case insensitive queries. 
```js
const name = "Tom";
const result = await t.queryRaw`
	SELECT COD, NAME FROM USERS WHERE ${{
    ["LOWER(NAME)"]: name.toLowerCase(),
  }}`.getQuery();

console.log(result);
// SELECT COD, NAME FROM USERS WHERE LOWER(NAME) = 'tom'
```
The example provided in the readme required to make it lowercase, this worked for some cases but when using characters like 'ı' and 'I' in Turkish didnt return all the values.