### PR TITLE
Replace object with tautology when its undefined

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -162,7 +162,9 @@ const handleObjectCondition = (
         condition = `${prefix}${key} CONTAINING ${escape(value)}`;
         break;
     }
-
+    if (value === undefined) {
+      condition = '1=1'      
+    }
     if (condition) {
       clauses.push(condition);
     }


### PR DESCRIPTION
Replaced operators with 1=1 if the operator value is undefined 
```js
const name = "Tom";
const result = await t.queryRaw`
	SELECT COD, NAME FROM USERS WHERE ${{
    COD: name.startsWith("J") ? 1 : undefined,
    NAME: name,
  }}`.getQuery();

console.log(result);
// SELECT COD, NAME FROM USERS WHERE 1=1 AND NAME = 'Tom'
```
The example provided in the docs was not working with objects. It was building a query with operator and empty string. 