### PR TITLE
Change updateOne to filter undefined values

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -267,9 +267,12 @@ const updateOneQuery = <T = void>({
   where,
 }: UpdateOneParams<T>) => {
   const toSet = Object.entries(rowValues).map(
-    ([columnName, value]) => `${columnName} = ${escape(value)}`
+    ([columnName, value]) => value ? `${columnName} = ${escape(value)}` : undefined
   );
-  const valuesStr = toSet.join(", ");
+  
+  const filteredToSet= toSet.filter(item => item !== undefined)
+
+  const valuesStr = filteredToSet.join(", ");
 
   const whereStr = buildWhereClause(where);
 


### PR DESCRIPTION
While using updateOne the following function produced following query

`const bCol = 'test';
`
`db.updateOne({tableName: 'A_TABLE', rowValues: {A_COLUMN: 'A', B_COLUMN: bCol}, where: {C_COLUMN: 'C'} })
`

`UPDATE A_TABLE SET A_COLUMN = 'A' , B_COLUMN = 'test' WHERE C_COLUMN = 'C' 
`

However, if one of the column values is undefined or not provided. It still included the column name in the query:

`const bCol = undefined 
`
`UPDATE A_TABLE SET A_COLUMN = 'A',  B_COLUMN = '  ' WHERE C_COLUMN = 'C' 
`

Now when no value is provided it builds the query like this:
`UPDATE A_TABLE SET A_COLUMN = 'A'  WHERE C_COLUMN = 'C' 
`